### PR TITLE
Fix memory leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,71 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# MacOS
+.DS_Store
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output

--- a/Tsuikaban/GameScene.swift
+++ b/Tsuikaban/GameScene.swift
@@ -41,7 +41,7 @@ class GameScene: SKScene {
     private var label : SKLabelNode?
     private var board: Board! = nil
     private var ignoreGesture = false
-    private var parentVC: GameViewController! = nil
+    private weak var parentVC: GameViewController! = nil
     // When the drag began
     private var firstPoint: CGPoint! = nil
     


### PR DESCRIPTION
Fixes a retain cycle. The GameScene had a strong reference to the GameViewController, and the GameViewController had a strong reference to the GameScene. Consequently, the retain counts were not reaching zero causing a memory leak. Breaking the cycle with a weak reference fixes the memory issue.

Also adds a gitignore file for Xcode projects.

![Screenshot 2019-11-30 at 20 33 34](https://user-images.githubusercontent.com/4864185/69905792-b29c9700-13b0-11ea-990e-6a7ff5d49a34.png)

This closes #1 .